### PR TITLE
Expand ECS interfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Install D compiler
-      uses: mihails-strasuns/setup-dlang@v0.5.0
+      uses: dlang-community/setup-dlang@v1
       with:
         compiler: ldc-latest
     - name: Install *nix Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Lint
       run: dub lint
     - name: Test
-      run: dub test --parallel --coverage
+      run: make cover
     - name: Upload Coverage to Codecov
       if: success()
       run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,6 @@ name: Documentation
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Documentation
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: dmd-latest
+      - name: Build Documentation
+        run: make docs
+
+      - name: GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2.1.2
+        with:
+          target_branch: gh-pages
+          build_dir: docs
+          keep_history: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -17,20 +17,15 @@ docs.json: $(DOCS_SOURCES)
 	dmd $(DOCS_SOURCES) -D -X -Xfdocs.json || true
 	rm -f *.o
 
-docs/sitemap.xml:
+docs/sitemap.xml: $(DOCS_SOURCES)
 	dub build -b ddox
 	@echo "Performing cosmetic changes..."
-	@sed -i "s/main-nav\">/main-nav\">\
-<h1>teraflop Engine<\/h1>\
-<p>API Reference<\/p>/" `find docs -name '*.html'`
+	@sed -i -e "/<nav id=\"main-nav\">/r views/nav.html" -e "/<nav id=\"main-nav\">/d" `find docs -name '*.html'`
+	@sed -i "s/<\/title>/ - Teraflop<\/title>/" `find docs -name '*.html'`
 	@sed -i "s/API documentation/API Reference/g" docs/index.html
-	@sed -i "s/<\/title>/ - teraflop<\/title>/" `find docs -name '*.html'`
+	@sed -i -e "/<h1>API Reference<\/h1>/r views/index.html" -e "/<h1>API Reference<\/h1>/d" docs/index.html
 	@sed -i "s/3-Clause BSD License/<a href=\"https:\/\/opensource.org\/licenses\/BSD-3-Clause\">3-Clause BSD License<\/a>/" `find docs -name '*.html'`
-	@sed -i "s/<p class=\"faint\">Generated using the DDOX documentation generator<\/p>/\
-<div style=\"display: flex; justify-content: space-between; margin-top: 2em\">\
-  <a href=\"https:\/\/github.com\/chances\/teraflop-d#readme\">GitHub<\/a>\
-  <span class=\"faint\" style=\"float: right;\">Generated using <a href=\"https:\/\/code.dlang.org\/packages\/ddox\">DDOX<\/a><\/span>\
-<\/div>/" `find docs -name '*.html'`
+	@sed -i -e "/<p class=\"faint\">Generated using the DDOX documentation generator<\/p>/r views/footer.html" -e "/<p class=\"faint\">Generated using the DDOX documentation generator<\/p>/d" `find docs -name '*.html'`
 	@echo Done
 
 docs: docs/sitemap.xml

--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,21 @@ docs.json: $(DOCS_SOURCES)
 
 docs/sitemap.xml:
 	dub build -b ddox
+	@echo "Performing cosmetic changes..."
+	@sed -i "s/main-nav\">/main-nav\">\
+<h1>teraflop Engine<\/h1>\
+<p>API Reference<\/p>/" `find docs -name '*.html'`
+	@sed -i "s/API documentation/API Reference/g" docs/index.html
+	@sed -i "s/<\/title>/ - teraflop<\/title>/" `find docs -name '*.html'`
+	@sed -i "s/3-Clause BSD License/<a href=\"https:\/\/opensource.org\/licenses\/BSD-3-Clause\">3-Clause BSD License<\/a>/" `find docs -name '*.html'`
+	@sed -i "s/<p class=\"faint\">Generated using the DDOX documentation generator<\/p>/\
+<div style=\"display: flex; justify-content: space-between; margin-top: 2em\">\
+  <a href=\"https:\/\/github.com\/chances\/teraflop-d#readme\">GitHub<\/a>\
+  <span class=\"faint\" style=\"float: right;\">Generated using <a href=\"https:\/\/code.dlang.org\/packages\/ddox\">DDOX<\/a><\/span>\
+<\/div>/" `find docs -name '*.html'`
+	@echo Done
 
-docs/file_hashes.json: $(DOCS_SOURCES) docs/index.html docs.json
-	dub run ddox -- filter --min-protection=Protected docs.json
-	dub run ddox -- generate-html --navigation-type=ModuleTree docs.json docs
-
-docs: docs/sitemap.xml docs/file_hashes.json
+docs: docs/sitemap.xml
 .PHONY: docs
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+SOURCES := $(shell find source -name '*.d')
+
+.DEFAULT_GOAL := docs
+all: docs
+
+test:
+	dub test --parallel
+.PHONY: test
+
+cover: $(SOURCES)
+	dub test --parallel --coverage
+
+# TODO: Fix this so I can include the window module
+DOCS_SOURCES := $(shell find source -name '*.d' ! -name 'window.d')
+docs.json: $(DOCS_SOURCES)
+	rm -f docs.json
+	dmd $(DOCS_SOURCES) -D -X -Xfdocs.json || true
+	rm -f *.o
+
+docs/sitemap.xml:
+	dub build -b ddox
+
+docs/file_hashes.json: $(DOCS_SOURCES) docs/index.html docs.json
+	dub run ddox -- filter --min-protection=Protected docs.json
+	dub run ddox -- generate-html --navigation-type=ModuleTree docs.json docs
+
+docs: docs/sitemap.xml docs/file_hashes.json
+.PHONY: docs
+
+clean:
+	rm -f bin/teraflop-test-library
+	rm -f docs.json
+	rm -rf docs
+	rm -f -- *.lst
+.PHONY: clean

--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # Teraflop
 
+[![DUB Package](https://img.shields.io/dub/v/teraflop.svg)](https://code.dlang.org/packages/teraflop)
 ![Teraflop CI](https://github.com/chances/teraflop-d/workflows/Teraflop%20CI/badge.svg?branch=master)
 [![codecov](https://codecov.io/gh/chances/teraflop-d/branch/master/graph/badge.svg?token=5YN3BU7KR3)](https://codecov.io/gh/chances/teraflop-d/)
 
 An ECS game engine on a [wgpu](https://github.com/gfx-rs/wgpu-native) foundation.
+
+## Usage
+
+```json
+"dependencies": {
+    "terflop": "0.1.0-pre-alpha-1"
+}
+```
+
+[API Reference](https://chances.github.io/teraflop-d)
+
+TODO: Add a "Hello, World!" example
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ TODO: Add a "Hello, World!" example
 
 ## License
 
+Teraflop's [ECS](https://en.wikipedia.org/wiki/Entity_component_system) implementation was inspired by [Bevy ECS](https://bevyengine.org/learn/book/getting-started/ecs) and [entt](https://github.com/skypjack/entt).
+
 [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 Copyright &copy; 2020 Chance Snow. All rights reserved.

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -100,6 +100,9 @@ unittest {
   assert(world.resources.get!Foo.bar == "hello");
 }
 
+/// Detect whether `T` is the `Entity` class.
+enum bool isEntity(T) = __traits(isSame, Unqual!T, Entity);
+
 /// A world entity consisting of a unique ID and a collection of associated components.
 final class Entity {
   private Component[string] components_;

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -470,7 +470,7 @@ abstract class System {
   ///         )
   ///       $(LI Try to find a matching World Resource to apply given the parameter's type is one of:)
   ///         $(UL
-  ///           $(LI <a href="https://dlang.org/spec/type.html#basic-data-types" title="The D Language Website">Basic Data</a>
+  ///           $(LI <a href="https://dlang.org/spec/type.html#basic-data-types" title="The D Language Website">Basic Data</a>)
   ///           $(LI arrays)
   ///           $(LI string)
   ///           $(LI `struct`)

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -426,6 +426,11 @@ template isSystem(T) {
   enum bool isSystem = isRawOrInherited!T;
 }
 
+/// A function that initializes a new dynamically generated System.
+///
+/// Use `System.from` to construct a `SystemGenerator` given a function that satisfies `isCallableAsSystem`.
+alias SystemGenerator = System function(World world);
+
 /// Derive this class to encapsulate a game system that operates on Resources and Components in the World.
 abstract class System {
   private string name_;
@@ -440,8 +445,7 @@ abstract class System {
     this.world = world;
   }
 
-  private alias SystemGenerator = System function(World world);
-  /// Dynamically construct a new `System` instance given a function.
+  /// Dynamically generate a new `System` instance given a function.
   ///
   /// When a generated System is run it will try to apply the World's Entities, Components, and Resources to the function's parameters. See Parameter Application below.
   ///

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -1,3 +1,9 @@
+/// Teraflop's Entity Component System primitives.
+///
+/// Inspired by <a href="https://bevyengine.org/learn/book/getting-started/ecs/">Bevy ECS</a> and <a href="https://github.com/skypjack/entt">entt</a>.
+///
+/// See_Also: <a href="https://en.wikipedia.org/wiki/Entity_component_system">Entity Component System</a> on Wikipedia
+///
 /// Authors: Chance Snow
 /// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
 /// License: 3-Clause BSD License

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -107,18 +107,25 @@ final class Entity {
 
   /// Add a `Component` instance to this entity.
   void add(Component component) {
-    auto name = component.classinfo.name ~ ":" ~ component.name;
-    components_[name] = component;
+    components_[key(component)] = component;
+  }
+
+  private static string key(Component component) {
+    return component.classinfo.name ~ ":" ~ component.name;
   }
 
   unittest {
     auto entity = new Entity();
     assert(entity.components.length == 0);
     auto seven = new Number(7, "seven");
+    import std.traits : fullyQualifiedName;
+    auto key = fullyQualifiedName!Number ~ ":seven";
+
+    assert(Entity.key(seven) == key);
     entity.add(seven);
     assert(entity.components.length == 1);
     assert(entity.components[0] == seven);
-    assert(entity.components_.keys[0] == "teraflop.ecs.Number:seven");
+    assert(entity.components_.keys[0] == Entity.key(seven));
   }
 }
 

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -4,7 +4,7 @@ import std.uuid : UUID;
 
 /// A collection of Entities, their `Component`s, `Resource`s, and the `System`s that operate on
 /// those components and mutate the world
-class World {
+final class World {
   private Entity[UUID] entities_;
   private ResourceCollection resources_;
   private ResourceTracker resourceChanged;
@@ -90,7 +90,7 @@ unittest {
 }
 
 /// A world entity consisting of a unique ID and a collection of associated components.
-class Entity {
+final class Entity {
   private Component[string] components_;
   import std.uuid : randomUUID;
   /// Unique ID of this entity

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -11,7 +11,7 @@ import std.uuid : UUID;
 
 import teraflop.traits : inheritsFrom, isStruct;
 
-/// Detect whether `T` is the `World` class
+/// Detect whether `T` is the `World` class.
 enum bool isWorld(T) = __traits(isSame, T, World);
 
 /// A collection of Entities, their `Component`s, and `Resource`s. `System`s operate on those
@@ -48,14 +48,14 @@ final class World {
   }
 }
 
-/// Detect whether `T` is the `Resources` class
+/// Detect whether `T` is the `Resources` class.
 enum bool isResources(T) = __traits(isSame, T, Resources);
 
 import std.traits : isBoolean, isNumeric, isSomeString;
 private alias isResourceData = templateOr!(isBoolean, isNumeric, isSomeString, isStruct);
 
 import std.variant : Variant;
-alias ResourceId = size_t;
+private alias ResourceId = size_t;
 private alias ResourceCollection = Variant[ResourceId];
 private alias ResourceTracker = bool[ResourceId];
 /// A collection of Resource instances identified by their type.

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -158,7 +158,7 @@ abstract class Component {
     return typeid(NamedComponent).isBaseOf(component.classinfo);
   }
 
-  package static bool isTag(Component component) {
+  package static bool isTag(inout Component component) {
     return typeid(Tag).isBaseOf(component.classinfo);
   }
 }
@@ -221,23 +221,28 @@ immutable(Tag) tag(string name) {
   return new Tag(name).idup;
 }
 
-// TODO: Move these tag declarations to GPU-ish and teraflop.assets (Asset cache Resource) modules
-
-/// Whether *all* of an `Entity`s GPU resources have been initialized.
-static immutable Initialized = tag("Initialized");
-/// Whether *all* of an `Entity`s `Asset` components have been loaded.
-static immutable Loaded = tag("Loaded");
-
 unittest {
-  assert(Initialized.name == Initialized.stringof);
-
   const foo = tag("foo");
+
   assert(foo.type == "teraflop.ecs.Tag");
   assert(foo.name == foo.stringof);
+  assert(Component.isTag(foo));
 
   auto entity = new Entity();
   entity.add(foo);
   assert(entity.hasTag(foo));
+}
+
+// TODO: Move these tag declarations to GPU-ish and teraflop.assets (Asset cache Resource) modules
+
+/// Whether *all* of an `Entity`s GPU resources have been initialized.
+static const Initialized = tag("Initialized");
+/// Whether *all* of an `Entity`s `Asset` components have been loaded.
+static const Loaded = tag("Loaded");
+
+unittest {
+  assert(Initialized.name == Initialized.stringof);
+  assert(Loaded.name == Loaded.stringof);
 }
 
 /// Derive this class to encapsulate a game system that operates on `Component`s in the world.

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -44,41 +44,41 @@ import std.variant : Variant;
 alias ResourceId = size_t;
 private alias ResourceCollection = Variant[ResourceId];
 private alias ResourceTracker = bool[ResourceId];
-/// A collection of resource instances identified by their type.
+/// A collection of Resource instances identified by their type.
 struct Resources {
   private ResourceCollection* resources;
   private ResourceTracker* resourceChanged;
 
-  /// Add a resource to the collection.
+  /// Add a Resource to the collection.
   void add(T)(T resource) {
     Variant resourceVariant = resource;
     (*resources)[resourceVariant.type.toHash] = resourceVariant;
   }
 
-  /// Returns `true` if and only if the given resource type can be found in the collection.
+  /// Returns `true` if and only if the given Resource type can be found in the collection.
   bool contains(T)() const {
     import std.algorithm.searching : canFind;
     return resources.keys.canFind(typeid(T).toHash);
   }
 
-  /// Returns a resource from the collection given its resource type.
+  /// Returns a Resource from the collection given its type.
   immutable(T) get(T)() {
-    assert(contains!T(), "Could not find resource!");
+    assert(contains!T(), "Could not find Resource!");
     auto variant = (*resources)[typeid(T).toHash];
     assert(variant.peek!T !is null);
     return variant.get!T;
   }
 
-  /// Replace a resource.
+  /// Replace a Resource.
   void replace(T)(T resource) {
-    assert(contains!T(), "A resource must first be added before replacement.");
+    assert(contains!T(), "A Resource must first be added before replacement.");
     const Variant resourceVariant = resource;
     auto key = resourceVariant.type.toHash;
     (*resources)[key] = resource;
     (*resourceChanged)[key] = true;
   }
 
-  /// Clear each resource's change detection tracking state.
+  /// Clear each Resource's change detection tracking state.
   void clearTrackers() {
     foreach (key; resourceChanged.keys) {
       (*resourceChanged)[key] = false;

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -339,6 +339,11 @@ unittest {
   assert(component.name == "teraflop.ecs.Number");
 }
 
+/// Initialize a new `Component`, optionally given default data and a custom name.
+Component component(T)(T data = T.init, const string name = "") if (isStruct!T) {
+  return new Structure!T(data, name);
+}
+
 /// A named, dataless Component used to flag Entities.
 final class Tag : NamedComponent {
   /// Initialize a new Tag

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -18,6 +18,12 @@ final class World {
     return entities_.values;
   }
 
+  /// Get an Entity given its unique ID.
+  const(Entity) get(UUID id) const {
+    assert((id in entities_) !is null, "Could not find Entity!");
+    return entities_[id];
+  }
+
   /// A collection of resource instances identified by their type.
   Resources resources() const @property {
     return Resources(
@@ -225,6 +231,14 @@ final class Entity {
       return cast(T[]) namedComponents.filter!(c => c.type == typeid(T).name)
         .map!(c => c.to!(const T)).array;
     }
+  }
+
+  /// Replace a Component given new value.
+  ///
+  /// Prefer [Plain Old Data](https://dlang.org/spec/struct.html#POD) structs for Component data.
+  void replace(Component component) {
+    assert(contains(component), "A Component must first be added before replacement.");
+    components_[key(component)] = component;
   }
 
   // TODO: Move this to the Component classes as a hash function and refactor components_ to use Component.hashOf

--- a/source/ecs.d
+++ b/source/ecs.d
@@ -485,7 +485,7 @@ abstract class System {
   abstract void run() const;
 
   /// Query the World for entities containing Components of the given types.
-  Entity[] query(ComponentT...)() {
+  const(Entity[]) query(ComponentT...)() const {
     static if (ComponentT.length == 0) return world.entities;
   }
 }

--- a/source/event.d
+++ b/source/event.d
@@ -1,3 +1,6 @@
+/// Authors: Chance Snow
+/// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
+/// License: 3-Clause BSD License
 module teraflop.event;
 
 // Adapted from https://forum.dlang.org/post/dcdtuqyrxpteuaxmvwft@forum.dlang.org

--- a/source/platform/window.d
+++ b/source/platform/window.d
@@ -1,3 +1,6 @@
+/// Authors: Chance Snow
+/// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
+/// License: 3-Clause BSD License
 module teraflop.platform.window;
 
 import bindbc.glfw;

--- a/source/time.d
+++ b/source/time.d
@@ -1,3 +1,6 @@
+/// Authors: Chance Snow
+/// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
+/// License: 3-Clause BSD License
 module teraflop.time;
 
 import core.time : Duration;

--- a/source/traits.d
+++ b/source/traits.d
@@ -1,3 +1,6 @@
+/// Authors: Chance Snow
+/// Copyright: Copyright © 2020 Chance Snow. All rights reserved.
+/// License: 3-Clause BSD License
 module teraflop.traits;
 
 /// Detect whether `T` is a struct type.
@@ -6,7 +9,7 @@ package enum bool isStruct(T) = is (T == struct);
 package enum bool isClass(T) = is (T == class);
 
 /// Detect whether `T` inherits from `U`.
-template inheritsFrom(T, U) if (isClass!T && isClass!U) {
+package template inheritsFrom(T, U) if (isClass!T && isClass!U) {
   import std.meta : anySatisfy;
   import std.traits : BaseClassesTuple, fullyQualifiedName;
   enum bool isBaseClassOfU(T) = __traits(isSame, fullyQualifiedName!T, fullyQualifiedName!U);

--- a/source/traits.d
+++ b/source/traits.d
@@ -8,7 +8,7 @@ package enum bool isClass(T) = is (T == class);
 /// Detect whether `T` inherits from `U`.
 template inheritsFrom(T, U) if (isClass!T && isClass!U) {
   import std.meta : anySatisfy;
-  import std.traits : BaseClassesTuple;
+  import std.traits : BaseClassesTuple, fullyQualifiedName;
   enum bool isBaseClassOfU(T) = __traits(isSame, fullyQualifiedName!T, fullyQualifiedName!U);
   enum bool inheritsFrom = anySatisfy!(isBaseClassOfU, BaseClassesTuple!T);
 }

--- a/source/traits.d
+++ b/source/traits.d
@@ -1,0 +1,14 @@
+module teraflop.traits;
+
+/// Detect whether `T` is a struct type.
+package enum bool isStruct(T) = is (T == struct);
+/// Detect whether `T` is a class type.
+package enum bool isClass(T) = is (T == class);
+
+/// Detect whether `T` inherits from `U`.
+template inheritsFrom(T, U) if (isClass!T && isClass!U) {
+  import std.meta : anySatisfy;
+  import std.traits : BaseClassesTuple;
+  enum bool isBaseClassOfU(T) = __traits(isSame, fullyQualifiedName!T, fullyQualifiedName!U);
+  enum bool inheritsFrom = anySatisfy!(isBaseClassOfU, BaseClassesTuple!T);
+}

--- a/views/footer.html
+++ b/views/footer.html
@@ -1,0 +1,4 @@
+<div style="display: flex; justify-content: space-between; margin-top: 2em;">
+  <a href="https://github.com/chances/teraflop-d#readme">GitHub</a>
+  <span class="faint" style="float: right;">Generated using <a href="https://code.dlang.org/packages/ddox">DDOX</a></span>
+</div>

--- a/views/index.html
+++ b/views/index.html
@@ -1,0 +1,23 @@
+<h1>Teraflop API Reference</h1>
+<p>
+  <a href="https://code.dlang.org/packages/teraflop">
+    <img src="https://img.shields.io/dub/v/teraflop.svg" alt="DUB Package">
+  </a>
+  <a target="_blank" href="https://opensource.org/licenses/BSD-3-Clause">
+    <img src="https://img.shields.io/badge/license-3--Clause%20BSD-blue" alt="3&dash;Clause BSD License">
+  </a>
+  <a target="_blank" rel="noopener noreferrer" href="https://github.com/chances/teraflop-d/workflows/Teraflop%20CI/badge.svg?branch=master">
+    <img src="https://github.com/chances/teraflop-d/workflows/Teraflop%20CI/badge.svg?branch=master" alt="Teraflop CI">
+  </a>
+  <a href="https://codecov.io/gh/chances/teraflop-d/">
+    <img src="https://codecov.io/gh/chances/teraflop-d/branch/master/graph/badge.svg" alt="codecov">
+  </a>
+</p>
+<p>An ECS game engine on a <a href="https://github.com/gfx-rs/wgpu-native">wgpu</a> foundation.</p>
+<h2 id="Usage">Usage</h2>
+<pre class="json">
+"dependencies": {
+  "terflop": "0.1.0-pre-alpha-1"
+}
+</pre>
+<h2>Modules</h2>

--- a/views/nav.html
+++ b/views/nav.html
@@ -1,0 +1,17 @@
+<nav id="main-nav">
+  <h1>Teraflop Engine</h1>
+  <ul style="list-style: none; padding: 0;">
+    <li>
+      <a href="https://chances.github.io/teraflop-d#Usage">Documentation</a>
+    </li>
+    <li>
+      <a href="https://chances.github.io/teraflop-d">API Reference</a>
+    </li>
+    <li>
+      <a href="https://code.dlang.org/packages/teraflop">Download</a>
+    </li>
+    <li>
+      <a href="https://github.com/chances/teraflop-d#readme">Open Source on GitHub</a>
+    </li>
+  </ul>
+  <h2>API Reference</h2>


### PR DESCRIPTION
- Add derivation of `Component` to store arbitrary structs
- Add `NamedComponent`
- Refactor tags to use `NamedComponent`
- Add `contains` functions for Entities
  - With overloads for named and struct components
- Add `get` functions for Entities
  - With templates for struct, unnamed, and named components
- Add `System.from` and `GeneratedSystem` class to dynamically bind functions as Systems, à la [Bevy ECS](https://bevyengine.org/learn/book/getting-started/ecs/)
- Add [Documentation](https://chances.github.io/teraflop-d)