### PR TITLE
Refactor `InputNode` and `InputEvent`

### DIFF
--- a/source/teraflop/input/event.d
+++ b/source/teraflop/input/event.d
@@ -105,13 +105,25 @@ class InputEventKeyboard : InputEvent {
   const int modifiers = 0;
 
   ///
-  this(const KeyboardKey key, bool pressed, bool held, int modifiers) {
+  this(const KeyboardKey key, bool pressed, bool held, int modifiers = 0) {
     super(InputDevice.keyboard);
     this.key = key;
     this.pressed = pressed && !held;
     this.held = held;
     this.modifiers = modifiers;
   }
+}
+
+unittest {
+  auto event = new InputEventKeyboard(KeyboardKey.enter, true, false);
+
+  assert(event.device == InputDevice.keyboard);
+  assert(!event.handled);
+  assert(event.isKeyboardEvent);
+  assert(event.asKeyboardEvent == event);
+
+  event.stopPropagation();
+  assert(event.handled);
 }
 
 ///
@@ -174,16 +186,23 @@ class InputEventMouse : InputEvent {
 unittest {
   auto event = new InputEventMouse(vec2d.init, vec2d.init);
 
+  assert(event.device == InputDevice.mouse);
+  assert(event.isMouseEvent);
+  assert(event.asMouseEvent == event);
+
   assert((event.buttons & MouseButton.LEFT) != MouseButton.LEFT);
   assert((event.buttons & MouseButton.RIGHT) != MouseButton.RIGHT);
   assert((event.buttons & MouseButton.MIDDLE) != MouseButton.MIDDLE);
 
   event.buttons |= MouseButton.RIGHT;
+  assert(!event.wasButtonJustClicked(MouseButton.LEFT));
+  assert(event.wasButtonJustPressed(MouseButton.RIGHT));
   assert((event.buttons & MouseButton.LEFT) != MouseButton.LEFT);
   assert((event.buttons & MouseButton.RIGHT) == MouseButton.RIGHT);
   assert((event.buttons & MouseButton.MIDDLE) != MouseButton.MIDDLE);
 
   event.buttons |= MouseButton.MIDDLE;
+  assert(event.wasButtonJustPressed(MouseButton.MIDDLE));
   assert((event.buttons & MouseButton.LEFT) != MouseButton.LEFT);
   assert((event.buttons & MouseButton.RIGHT) == MouseButton.RIGHT);
   assert((event.buttons & MouseButton.MIDDLE) == MouseButton.MIDDLE);
@@ -220,4 +239,13 @@ class InputEventAction : InputEvent {
     InputEventAction other = cast(InputEventAction) o;
     return other && device == other.device && action == other.action;
   }
+}
+
+unittest {
+  auto event = new InputEventAction(InputDevice.keyboard, "cancel");
+  event.pressed = true;
+
+  assert(event.device == InputDevice.keyboard);
+  assert(event.isActionEvent);
+  assert(event.asActionEvent == event);
 }

--- a/source/teraflop/input/event.d
+++ b/source/teraflop/input/event.d
@@ -24,6 +24,7 @@ enum InputDevice {
 abstract class InputEvent {
   ///
   const InputDevice device;
+  private bool _handled = false;
 
   ///
   this(const InputDevice device) {
@@ -38,6 +39,12 @@ abstract class InputEvent {
   override bool opEquals(Object o) @safe @nogc const pure {
     InputEvent other = cast(InputEvent) o;
     return other && device == other.device;
+  }
+
+  /// Whether this `InputEvent` has been handled.
+  /// See_Also: `stopPropagation`
+  bool handled() @property const {
+    return _handled;
   }
 
   bool isKeyboardEvent() @property const {
@@ -74,6 +81,12 @@ abstract class InputEvent {
       return cast(InputEventAction) this;
     }
     return null;
+  }
+
+  /// Mark this `InputEvent` as handled, stopping propagation through the input tree.
+  /// See_Also: `handled`
+  void stopPropagation() {
+    _handled = true;
   }
 }
 

--- a/source/teraflop/input/package.d
+++ b/source/teraflop/input/package.d
@@ -127,15 +127,14 @@ final class Input {
 }
 
 /// A node in the input event tree.
-abstract class InputNode {
+interface InputNode {
   ///
-  void actionInput(const InputEventAction event) {
-    assert(event.action.length);
-  }
+  void actionInput(const InputEventAction event);
 
-  ///
-  bool unhandledInput(const InputEvent event) {
-    assert(event.device);
-    return false;
-  }
+  /// Returns: Whether the mark the given input `event` as handled, stopping propagation through the input tree.
+  bool unhandledInput(const InputEvent event);
+}
+
+unittest {
+  // TODO: Test an event tree
 }

--- a/source/teraflop/input/package.d
+++ b/source/teraflop/input/package.d
@@ -110,7 +110,7 @@ final class Input {
 
     foreach (handlers; nodes) {
       if (actionEvents.length) foreach (actionEvent; actionEvents) handlers.actionHandler(actionEvent);
-      if (handlers.unhandledHandler(event)) break;
+      if (handlers.unhandledHandler(event) || event.handled) break;
     }
   }
 

--- a/source/teraflop/platform/window.d
+++ b/source/teraflop/platform/window.d
@@ -193,7 +193,7 @@ class Window : InputNode {
 
   override bool unhandledInput(const InputEvent event) {
     onUnhandledInput(event);
-    return false;
+    return true; // Mark handled
   }
 
   extern(C) {


### PR DESCRIPTION
- Refactor `InputNode` into an interface
- Add `InputEvent.handled` property and `InputEvent.stopPropagation` method