### PR TITLE
Refactor input module

### DIFF
--- a/source/teraflop/game.d
+++ b/source/teraflop/game.d
@@ -195,7 +195,7 @@ abstract class Game {
     // Setup main window
     auto mainWindow = new Window(name);
     enforce(mainWindow.valid, "Could not open main game window!");
-    input[mainWindow] = new Input();
+    input[mainWindow] = new Input(mainWindow);
     input[mainWindow].addNode(mainWindow);
     mainWindow.onUnhandledInput ~= (const InputEvent event) => {
       newInput[event.device] = event;

--- a/source/teraflop/input/event.d
+++ b/source/teraflop/input/event.d
@@ -130,6 +130,7 @@ unittest {
   assert(!event.handled);
   assert(event.isKeyboardEvent);
   assert(event.asKeyboardEvent == event);
+  assert(event == new InputEventKeyboard(event.key, event.pressed, event.held));
 
   event.stopPropagation();
   assert(event.handled);

--- a/source/teraflop/input/event.d
+++ b/source/teraflop/input/event.d
@@ -4,11 +4,20 @@
 module teraflop.input.event;
 
 import teraflop.math : vec2d;
+import teraflop.input : MouseButton;
 import teraflop.input.keyboard;
 import teraflop.traits;
 
 alias ActionInput = void delegate(const InputEventAction event);
 alias UnhandledInput = bool delegate(const InputEvent event);
+
+///
+struct InputEventHandlers {
+  ///
+  const ActionInput actionHandler;
+  ///
+  const UnhandledInput unhandledHandler;
+}
 
 /// The user input device from which an `InputEvent` originated.
 enum InputDevice {
@@ -126,24 +135,12 @@ unittest {
   assert(event.handled);
 }
 
-///
-enum MouseButton {
-  ///
-  NONE = 0,
-  ///
-  LEFT = 1,
-  ///
-  RIGHT = 2,
-  ///
-  MIDDLE = 4
-}
-
 /// Mouse button and/or motion event.
 class InputEventMouse : InputEvent {
   /// One of or a bitwise combination of `MouseButton`s that are down.
-  int buttons = MouseButton.NONE;
+  int buttons = MouseButton.none;
   /// One of or a bitwise combination of `MouseButton`s that were just down.
-  int lastButtons = MouseButton.NONE;
+  int lastButtons = MouseButton.none;
   ///
   const bool buttonsChanged = false;
   ///

--- a/source/teraflop/input/event.d
+++ b/source/teraflop/input/event.d
@@ -245,4 +245,5 @@ unittest {
   assert(event.device == InputDevice.keyboard);
   assert(event.isActionEvent);
   assert(event.asActionEvent == event);
+  assert(event == new InputEventAction(event.device, event.action));
 }

--- a/source/teraflop/input/event.d
+++ b/source/teraflop/input/event.d
@@ -187,22 +187,22 @@ unittest {
   assert(event.isMouseEvent);
   assert(event.asMouseEvent == event);
 
-  assert((event.buttons & MouseButton.LEFT) != MouseButton.LEFT);
-  assert((event.buttons & MouseButton.RIGHT) != MouseButton.RIGHT);
-  assert((event.buttons & MouseButton.MIDDLE) != MouseButton.MIDDLE);
+  assert((event.buttons & MouseButton.left) != MouseButton.left);
+  assert((event.buttons & MouseButton.right) != MouseButton.right);
+  assert((event.buttons & MouseButton.middle) != MouseButton.middle);
 
-  event.buttons |= MouseButton.RIGHT;
-  assert(!event.wasButtonJustClicked(MouseButton.LEFT));
-  assert(event.wasButtonJustPressed(MouseButton.RIGHT));
-  assert((event.buttons & MouseButton.LEFT) != MouseButton.LEFT);
-  assert((event.buttons & MouseButton.RIGHT) == MouseButton.RIGHT);
-  assert((event.buttons & MouseButton.MIDDLE) != MouseButton.MIDDLE);
+  event.buttons |= MouseButton.right;
+  assert(!event.wasButtonJustClicked(MouseButton.left));
+  assert(event.wasButtonJustPressed(MouseButton.right));
+  assert((event.buttons & MouseButton.left) != MouseButton.left);
+  assert((event.buttons & MouseButton.right) == MouseButton.right);
+  assert((event.buttons & MouseButton.middle) != MouseButton.middle);
 
-  event.buttons |= MouseButton.MIDDLE;
-  assert(event.wasButtonJustPressed(MouseButton.MIDDLE));
-  assert((event.buttons & MouseButton.LEFT) != MouseButton.LEFT);
-  assert((event.buttons & MouseButton.RIGHT) == MouseButton.RIGHT);
-  assert((event.buttons & MouseButton.MIDDLE) == MouseButton.MIDDLE);
+  event.buttons |= MouseButton.middle;
+  assert(event.wasButtonJustPressed(MouseButton.middle));
+  assert((event.buttons & MouseButton.left) != MouseButton.left);
+  assert((event.buttons & MouseButton.right) == MouseButton.right);
+  assert((event.buttons & MouseButton.middle) == MouseButton.middle);
 }
 
 /// Mapped action input event.

--- a/source/teraflop/input/keyboard.d
+++ b/source/teraflop/input/keyboard.d
@@ -10,36 +10,36 @@ import bindbc.glfw;
 ///
 enum Modifiers {
   ///
-  NONE = 0,
+  none = 0,
   ///
-  SHIFT = 1,
+  shift = 1,
   ///
-  CONTROL = 2,
+  control = 2,
   ///
-  ALT = 4,
+  alt = 4,
   ///
-  SUPER = 8,
+  super_ = 8,
   ///
-  LEFT_SHIFT = 16,
+  leftShift = 16,
   ///
-  LEFT_CONTROL = 32,
+  leftControl = 32,
   ///
-  LEFT_ALT = 64,
+  leftAlt = 64,
   ///
-  LEFT_SUPER = 128,
+  leftSuper = 128,
   ///
-  RIGHT_SHIFT = 256,
+  rightShift = 256,
   ///
-  RIGHT_CONTROL = 512,
+  rightControl = 512,
   ///
-  RIGHT_ALT = 1024,
+  rightAlt = 1024,
   ///
-  RIGHT_SUPER = 2048,
+  rightSuper = 2048,
 
   /// Added in GLFW 3.3
-  CAPS_LOCK = 0x0010,
+  capsLock = 0x0010,
   /// Added in GLFW 3.3
-  NUM_LOCK = 0x0020,
+  numLock = 0x0020,
 }
 
 ///

--- a/source/teraflop/input/map.d
+++ b/source/teraflop/input/map.d
@@ -59,26 +59,26 @@ class InputMapBinding {
   StrengthCurve strengthCurve = null;
 
   ///
-  InputMapBinding keyboardPressed(KeyboardKey key, Modifiers modifiers = Modifiers.NONE) {
+  InputMapBinding keyboardPressed(KeyboardKey key, Modifiers modifiers = Modifiers.none) {
     states ~= BindingState.keyboard(true, false, key, modifiers);
     return this;
   }
 
   ///
-  InputMapBinding keyboardHeld(KeyboardKey key, Modifiers modifiers = Modifiers.NONE) {
+  InputMapBinding keyboardHeld(KeyboardKey key, Modifiers modifiers = Modifiers.none) {
     states ~= BindingState.keyboard(false, true, key, modifiers);
     return this;
   }
 
   ///
-  InputMapBinding keyboardDown(KeyboardKey key, Modifiers modifiers = Modifiers.NONE) {
+  InputMapBinding keyboardDown(KeyboardKey key, Modifiers modifiers = Modifiers.none) {
     states ~= BindingState.keyboard(true, false, key, modifiers);
     states ~= BindingState.keyboard(false, true, key, modifiers);
     return this;
   }
 
   ///
-  InputMapBinding keyboardReleased(KeyboardKey key, Modifiers modifiers = Modifiers.NONE) {
+  InputMapBinding keyboardReleased(KeyboardKey key, Modifiers modifiers = Modifiers.none) {
     states ~= BindingState.keyboard(false, false, key, modifiers);
     return this;
   }
@@ -192,8 +192,8 @@ private struct BindingState {
   /// A member of `KeyboardKey`
   int key = 0;
   /// A bitwise combitation of keyboard `Modifiers`
-  int modifiers = Modifiers.NONE;
-  auto button = MouseButton.NONE;
+  int modifiers = Modifiers.none;
+  auto button = MouseButton.none;
   bool wheel = false;
   bool motion = false;
   /// A bitwise combitation of `Axis`

--- a/source/teraflop/input/map.d
+++ b/source/teraflop/input/map.d
@@ -48,6 +48,11 @@ static StrengthCurve double_ = (float x, float last = 0.0) => x + x;
 /// Increases the strength by continuious accumulation, i.e. linearly.
 static StrengthCurve accumulation = (float x, float last = 0.0) => x + last;
 
+unittest {
+  assert(double_(2) == 4);
+  assert(accumulation(1, 1) == 2);
+}
+
 /// An `InputEventAction` builder.
 /// See_Also: <a href="https://refactoring.guru/design-patterns/builder">Builder Design Pattern</a> on <a href="https://refactoring.guru">refactoring.guru</a>
 class InputMapBinding {

--- a/source/teraflop/input/map.d
+++ b/source/teraflop/input/map.d
@@ -7,6 +7,7 @@
 /// License: 3-Clause BSD License
 module teraflop.input.map;
 
+import teraflop.input : MouseButton;
 import teraflop.input.event;
 import teraflop.input.keyboard;
 import teraflop.math : vec2d;
@@ -268,7 +269,7 @@ private struct BindingState {
     motionAxesApply = motionAxesApply || motionAxes == 0;
 
     bool buttonApplies = true;
-    if (button != MouseButton.NONE) {
+    if (button != MouseButton.none) {
       // Check that the event's button state matches this binding's expectation
       const isButtonPressed = (event.buttons & button) == button;
 

--- a/source/teraflop/input/package.d
+++ b/source/teraflop/input/package.d
@@ -21,11 +21,47 @@ struct InputEventHandlers {
 ///
 final class Input {
   import std.typecons : Flag, No;
+  import teraflop.math : vec2d;
   import teraflop.platform : Window;
 
   ///
   const(InputEventHandlers)[] nodes;
+  private Window window;
   private auto _map = new InputMap();
+
+  package (teraflop) this(Window window) {
+    this.window = window;
+  }
+
+  ///
+  bool isKeyDown(KeyboardKey key) @property const {
+    return window.isKeyDown(key);
+  }
+  ///
+  bool wasKeyDown(KeyboardKey key) @property const {
+    return window.wasKeyDown(key);
+  }
+  ///
+  bool isKeyReleased(KeyboardKey key) @property const {
+    return window.isKeyReleased(key);
+  }
+
+  ///
+  vec2d mousePosition() @property const {
+    return window.mousePosition;
+  }
+  ///
+  vec2d lastMousePosition() @property const {
+    return window.lastMousePosition;
+  }
+  ///
+  int mouseButtons() @property const {
+    return window.mouseButtons;
+  }
+  ///
+  int lastMouseButtons() @property const {
+    return window.lastMouseButtons;
+  }
 
   ///
   static ActionInput ignoreActions() {

--- a/source/teraflop/input/package.d
+++ b/source/teraflop/input/package.d
@@ -11,11 +11,15 @@ public import teraflop.input.keyboard;
 public import teraflop.input.map;
 
 ///
-struct InputEventHandlers {
+enum MouseButton {
   ///
-  const ActionInput actionHandler;
+  none = 0,
   ///
-  const UnhandledInput unhandledHandler;
+  left = 1,
+  ///
+  right = 2,
+  ///
+  middle = 4
 }
 
 ///

--- a/source/teraflop/input/package.d
+++ b/source/teraflop/input/package.d
@@ -117,22 +117,22 @@ final class Input {
       if (window.isKeyDown(key) || (window.isKeyReleased(key) && window.wasKeyDown(key))) {
         int keyModifiers = 0;
         if (window.isKeyDown(KeyboardKey.leftShift))
-          keyModifiers |= Modifiers.SHIFT | Modifiers.LEFT_SHIFT;
+          keyModifiers |= Modifiers.shift | Modifiers.leftShift;
         if (window.isKeyDown(KeyboardKey.leftControl))
-          keyModifiers |= Modifiers.CONTROL | Modifiers.LEFT_CONTROL;
+          keyModifiers |= Modifiers.control | Modifiers.leftControl;
         if (window.isKeyDown(KeyboardKey.leftAlt))
-          keyModifiers |= Modifiers.ALT | Modifiers.LEFT_ALT;
+          keyModifiers |= Modifiers.alt | Modifiers.leftAlt;
         if (window.isKeyDown(KeyboardKey.leftSuper))
-          keyModifiers |= Modifiers.SUPER | Modifiers.LEFT_SUPER;
+          keyModifiers |= Modifiers.super_ | Modifiers.leftSuper;
 
         if (window.isKeyDown(KeyboardKey.rightShift))
-          keyModifiers |= Modifiers.SHIFT | Modifiers.RIGHT_SHIFT;
+          keyModifiers |= Modifiers.shift | Modifiers.rightShift;
         if (window.isKeyDown(KeyboardKey.rightControl))
-          keyModifiers |= Modifiers.CONTROL | Modifiers.RIGHT_CONTROL;
+          keyModifiers |= Modifiers.control | Modifiers.rightControl;
         if (window.isKeyDown(KeyboardKey.rightAlt))
-          keyModifiers |= Modifiers.ALT | Modifiers.RIGHT_ALT;
+          keyModifiers |= Modifiers.alt | Modifiers.rightAlt;
         if (window.isKeyDown(KeyboardKey.rightSuper))
-          keyModifiers |= Modifiers.SUPER | Modifiers.RIGHT_SUPER;
+          keyModifiers |= Modifiers.super_ | Modifiers.rightSuper;
 
         propagate(new InputEventKeyboard(
           key, window.isKeyDown(key), window.isKeyDown(key) && window.wasKeyDown(key), keyModifiers

--- a/source/teraflop/platform/window.d
+++ b/source/teraflop/platform/window.d
@@ -250,9 +250,9 @@ class Window : InputNode {
       this.hovered = glfwGetWindowAttrib(window, GLFW_HOVERED) == GLFW_TRUE;
       this.lastMouseButtons = this.mouseButtons;
       this.mouseButtons = 0;
-      if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS) this.mouseButtons |= MouseButton.LEFT;
-      if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS) this.mouseButtons |= MouseButton.RIGHT;
-      if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_MIDDLE) == GLFW_PRESS) this.mouseButtons |= MouseButton.MIDDLE;
+      if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_LEFT) == GLFW_PRESS) this.mouseButtons |= MouseButton.left;
+      if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_RIGHT) == GLFW_PRESS) this.mouseButtons |= MouseButton.right;
+      if (glfwGetMouseButton(window, GLFW_MOUSE_BUTTON_MIDDLE) == GLFW_PRESS) this.mouseButtons |= MouseButton.middle;
       // Keyboard input
       foreach (key; keyPressed.keys)
         wasKeyPressed[key] = (key in keyPressed) !is null ? keyPressed[key] : false;

--- a/source/teraflop/platform/window.d
+++ b/source/teraflop/platform/window.d
@@ -110,10 +110,9 @@ class Window : InputNode {
   string title() @property const {
     return _title;
   }
-  void title(string value) @property {
+  void title(const string value) @property {
     _title = value;
-
-    if (valid) glfwSetWindowTitle(window, toStringz(_title));
+    if (valid) glfwSetWindowTitle(window, value.toStringz);
   }
 
   /// Size of this Window, in <a href="https://www.glfw.org/docs/latest/intro_guide.html#coordinate_systems">screen coordinates</a>.


### PR DESCRIPTION
- Refactor `Window.title` setter parameter type
- Move `MouseButton` enum to the `teraflop.input` module
- Rename `MouseButton` and `Modifiers` enum members to camel case