### PR TITLE
Include Materials' Textures in pipeline bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,13 @@ cube: bin/cube
 .PHONY: cube
 
 test:
-	dub test --parallel --config=unittest-gpu
+	dub test --coverage --config=unittest-gpu
+	./scripts/delete-junk-lst-files.sh
 .PHONY: test
 
 scripts/upload-coverage.sh:
 	echo "See 'Upload Coverage to Codecov' task in .github/workflows/ci.yml"
-cover: $(SOURCES) scripts/upload-coverage.sh
-	dub test --parallel --coverage --config=unittest-gpu
-	./scripts/delete-junk-lst-files.sh
+cover: $(SOURCES) scripts/upload-coverage.sh test
 	./scripts/upload-coverage.sh
 
 docs/sitemap.xml: $(SOURCES)

--- a/source/teraflop/ecs.d
+++ b/source/teraflop/ecs.d
@@ -55,6 +55,15 @@ final class World {
   }
 }
 
+version (unittest) {
+  class MockScene {
+    protected World world = new World();
+
+    /// Called when the Scene should initialize its `World`.
+    protected abstract void initializeWorld(scope World world);
+  }
+}
+
 /// Detect whether `T` is the `Resources` struct.
 enum bool isResources(T) = __traits(isSame, T, Resources);
 

--- a/source/teraflop/game.d
+++ b/source/teraflop/game.d
@@ -182,13 +182,7 @@ abstract class Game {
     eventLoop.exit();
 
     // Gracefully release GPU and other unmanaged resources
-    foreach (entity; world.entities) {
-      device.waitIdle();
-      foreach (component; entity.components) {
-        device.waitIdle();
-        destroy(component);
-      }
-    }
+    new ResourceGarbageCollector(world, device).run();
     foreach (system; systems) destroy(system);
     destroy(world);
 
@@ -201,8 +195,6 @@ abstract class Game {
       destroy(window);
     }
 
-    device.waitIdle();
-    new ResourceGarbageCollector(world, device).run();
     destroy(pipelinePreparer);
 
     device.waitIdle();

--- a/source/teraflop/graphics/package.d
+++ b/source/teraflop/graphics/package.d
@@ -882,7 +882,7 @@ class Texture : BindingDescriptor, IResource {
   }
 
   /// Resize this Texture.
-  void resize(Size size) {
+  void resize(const Size size) {
     import std.algorithm : joiner, map;
     import std.array : array;
     import std.math : round;
@@ -1226,7 +1226,7 @@ class Material : ObservableFileCollection, IResource {
   }
 
   /// Initialize this Material.
-  void initialize(scope Device device) {
+  override void initialize(scope Device device) {
     foreach (shader; _shaders) shader.initialize(device);
     if (_texture !is null)
       texture.initialize(device);
@@ -1270,133 +1270,201 @@ version (GPU) {
   import teraflop.platform.vulkan;
 }
 
-unittest {
+version (unittest) {
   version (GPU) {
-    import gfx.core : none;
-    import std.conv : to;
+    import teraflop.ecs : MockScene, System, World;
+    import teraflop.systems;
 
-    assert(initVulkan("test-triangle"));
-    const graphicsQueueIndex = selectGraphicsQueue();
-    enforce(graphicsQueueIndex >= 0, "Try upgrading your graphics drivers.");
-    auto device = selectGraphicsDevice(graphicsQueueIndex);
-    auto graphicsQueue = device.getQueue(graphicsQueueIndex, 0);
+    class MockTriangleScene : MockScene, SurfaceSizeProvider {
 
-    // Render a blank scene to a single image
-    auto renderTargetSize = Size(400, 400);
-    auto renderTarget = createImage(device, renderTargetSize, Format.bgra8_sRgb, ImageUsage.colorAttachment);
-    auto renderTargetTexture = new Texture(Size(renderTargetSize.width / 2, renderTargetSize.width / 2));
-    renderTargetTexture.initialize(device);
-    assert(renderTargetTexture.initialized);
-    renderTargetTexture.resize(renderTargetSize);
-    assert(!renderTargetTexture.initialized);
-    renderTargetTexture.initialize(device);
-    assert(renderTargetTexture.initialized);
+      const Size renderTargetSize;
 
-    const attachments = [AttachmentDescription(Format.bgra8_sRgb, 1,
-      AttachmentOps(LoadOp.clear, StoreOp.store),
-      AttachmentOps(LoadOp.dontCare, StoreOp.dontCare),
-      trans(ImageLayout.undefined, ImageLayout.presentSrc),
-      No.mayAlias
-    )];
-    const subpasses = [SubpassDescription(
-      [], [ AttachmentRef(0, ImageLayout.colorAttachmentOptimal) ],
-      none!AttachmentRef, []
-    )];
-    auto renderPass = device.createRenderPass(attachments, subpasses, []);
-    auto frameBuffer = new TestFrameData(device, graphicsQueueIndex, renderTarget, renderPass);
+      private Device _device;
+      private Queue graphicsQueue;
+      private Image _renderTarget;
+      private Texture _renderTargetTexture;
+      private Rc!RenderPass renderPass;
+      private TestFrameData frameBuffer;
+      private PipelinePreparer pipelinePreparer;
+      private auto systems = new System[0];
 
-    auto triangle = new Mesh!VertexPosColor([
-      VertexPosColor(vec3f(0.0f, -0.5f, 0), Color.red.vec3f),
-      VertexPosColor(vec3f(0.5f, 0.5f, 0), Color.green.vec3f),
-      VertexPosColor(vec3f(-0.5f, 0.5f, 0), Color.blue.vec3f),
-    ], [0, 1, 2]);
-    triangle.initialize(device);
-    assert(triangle.initialized);
-    assert(triangle.dirty);
-    assert(triangle.vertexCount == 3);
-    assert(triangle.indices == [0, 1, 2]);
+      private MeshBase _triangle;
+      private Material _material;
 
-    auto vert = new Shader(ShaderStage.vertex, "examples/triangle/assets/shaders/triangle.vs.spv");
-    auto frag = new Shader(ShaderStage.fragment, "examples/triangle/assets/shaders/triangle.fs.spv");
-    auto material = new Material([vert, frag], No.depthTest);
-    assert( material.frontFace == FrontFace.clockwise);
-    assert( material.cullMode == CullMode.back);
-    assert(!material.textured);
-    assert(!material.dirty);
-    material.initialize(device);
-    assert(vert.initialized && frag.initialized);
-    assert(material.initialized);
+      this(Size renderTargetSize = Size(400, 400)) {
+        import gfx.core : none;
 
-    Pipeline[Material] pipelines;
-    DescriptorSetLayout[] descriptors;
-    PipelineInfo info = {
-      shaders: material.shaders,
-      inputBindings: [triangle.bindingDescription],
-      inputAttribs: triangle.attributeDescriptions,
-      assembly: InputAssembly(Primitive.triangleList, No.primitiveRestart),
-      rasterizer: Rasterizer(
-        PolygonMode.fill, material.cullMode, material.frontFace, No.depthClamp,
-        none!DepthBias, 1f
-      ),
-      viewports: [
-        ViewportConfig(
-          Viewport(0, 0, renderTargetSize.width.to!float, renderTargetSize.height.to!float),
-          Rect(0, 0, renderTargetSize.width, renderTargetSize.height)
-        )
-      ],
-      blendInfo: ColorBlendInfo(
-        none!LogicOp, [
-          ColorBlendAttachment(No.enabled,
-            BlendState(trans(BlendFactor.one, BlendFactor.zero), BlendOp.add),
-            BlendState(trans(BlendFactor.one, BlendFactor.zero), BlendOp.add),
-            ColorMask.all
-          )
-        ],
-        [ 0f, 0f, 0f, 0f ]
-      ),
-      layout: device.createPipelineLayout(descriptors.length ? descriptors : [], []),
-      renderPass: renderPass,
-      subpassIndex: 0
-    };
-    pipelines[material] = device.createPipelines([info])[0];
+        assert(initVulkan("test-triangle"));
+        const graphicsQueueIndex = selectGraphicsQueue();
+        enforce(graphicsQueueIndex >= 0, "Try upgrading your graphics drivers.");
+        _device = selectGraphicsDevice(graphicsQueueIndex);
+        graphicsQueue = _device.getQueue(graphicsQueueIndex, 0);
 
-    auto commands = frameBuffer.cmdPool.allocatePrimary(1)[0];
-    commands.begin(CommandBufferUsage.oneTimeSubmit);
-    const clearColor = Color.black.toVulkan;
-    commands.beginRenderPass(
-      renderPass, frameBuffer.frameBuffer,
-      Rect(0, 0, renderTargetSize.width, renderTargetSize.height),
-      [ClearValues(clearColor)]
-    );
-    commands.bindPipeline(pipelines[material]);
-    commands.bindVertexBuffers(0, [VertexBinding(triangle.vertexBuffer, 0)]);
-    commands.bindIndexBuffer(triangle.indexBuffer, 0, IndexType.u32);
-    commands.drawIndexed(triangle.indices.length.to!uint, 1, 0, 0, 0);
-    commands.endRenderPass();
-    commands.end();
-    // TODO: Diff with a PPM file (https://github.com/aquaratixc/ppmformats), e.g. https://github.com/mruby/mruby/blob/master/benchmark/bm_ao_render.rb#L308
+        this.renderTargetSize = renderTargetSize;
+        _renderTarget = createImage(_device, renderTargetSize, Format.bgra8_sRgb, ImageUsage.colorAttachment);
+        _renderTargetTexture = new Texture(Size(renderTargetSize.width / 2, renderTargetSize.width / 2));
+        _renderTargetTexture.initialize(_device);
 
-    auto submissions = [Submission([], [], [commands])];
-    graphicsQueue.submit(submissions, null);
+        // Setup render pass
+        const attachments = [AttachmentDescription(renderTarget.info.format, 1,
+          AttachmentOps(LoadOp.clear, StoreOp.store),
+          AttachmentOps(LoadOp.dontCare, StoreOp.dontCare),
+          trans(ImageLayout.undefined, ImageLayout.presentSrc),
+          No.mayAlias
+        )];
+        const subpasses = [SubpassDescription(
+          [], [ AttachmentRef(0, ImageLayout.colorAttachmentOptimal) ],
+          none!AttachmentRef, []
+        )];
+        renderPass = _device.createRenderPass(attachments, subpasses, []);
+        frameBuffer = new TestFrameData(_device, graphicsQueueIndex, renderTarget, renderPass);
 
-    // Render one frame
-    device.waitIdle();
+        // Setup pipeline preparer
+        pipelinePreparer = new PipelinePreparer(world, _device, renderPass.obj);
 
-    // Gracefully teardown GPU resources
-    destroy(material);
-    destroy(triangle);
+        // Setup built-in Systems
+        systems ~= new ResourceInitializer(world, _device);
+        systems ~= new TextureUploader(world, new OneTimeCmdBufPool(_device, graphicsQueue));
+      }
+      ~this() {
+        // Gracefully release GPU and other unmanaged resources
+        new ResourceGarbageCollector(world, _device).run();
+        foreach (system; systems) destroy(system);
+        _device.waitIdle();
+        destroy(world);
 
-    foreach (pipeline; pipelines.values) {
-      device.waitIdle();
-      pipeline.dispose();
+        destroy(pipelinePreparer);
+
+        _device.waitIdle();
+        destroy(_renderTargetTexture);
+        // TODO: Figure out why releasing these objects crashes
+        // _renderTarget.release();
+        // renderPass.dispose();
+        frameBuffer.dispose();
+
+        _device.waitIdle();
+        _device.release();
+        unloadVulkan();
+      }
+
+      const(Size) surfaceSize() @property const {
+        return renderTargetSize;
+      }
+
+      @property Device device() {
+        return _device;
+      }
+      @property Image renderTarget() {
+        return _renderTarget;
+      }
+      @property Texture renderTargetTexture() {
+        return _renderTargetTexture;
+      }
+      @property MeshBase triangle() {
+        return _triangle;
+      }
+      @property Material material() {
+        return _material;
+      }
+
+      void initializeWorld() {
+        initializeWorld(world);
+      }
+
+      protected override void initializeWorld(scope World world) {
+        world.resources.add(this);
+
+        _triangle = new Mesh!VertexPosColor([
+          VertexPosColor(vec3f(0.0f, -0.5f, 0), Color.red.vec3f),
+          VertexPosColor(vec3f(0.5f, 0.5f, 0), Color.green.vec3f),
+          VertexPosColor(vec3f(-0.5f, 0.5f, 0), Color.blue.vec3f),
+        ], [0, 1, 2]);
+        _material = new Material([
+          new Shader(ShaderStage.vertex, "examples/triangle/assets/shaders/triangle.vs.spv"),
+          new Shader(ShaderStage.fragment, "examples/triangle/assets/shaders/triangle.fs.spv")
+        ], No.depthTest);
+
+        world.spawn(_triangle, _material);
+      }
+
+      void update() {
+        import std.exception : assertNotThrown;
+        import teraflop.ecs : SystemException;
+
+        pipelinePreparer.run();
+
+        foreach (system; systems)
+          assertNotThrown!SystemException(system.run());
+      }
+
+      void renderFrame() {
+        update();
+
+        auto commands = frameBuffer.cmdPool.allocatePrimary(1)[0];
+        commands.begin(CommandBufferUsage.oneTimeSubmit);
+        const clearColor = Color.black.toVulkan;
+        commands.beginRenderPass(
+          renderPass, frameBuffer.frameBuffer,
+          Rect(0, 0, renderTargetSize.width, renderTargetSize.height),
+          [ClearValues(clearColor)]
+        );
+        foreach (renderable; pipelinePreparer.renderables) {
+          commands.bindPipeline(cast(Pipeline) renderable.pipeline);
+          commands.bindVertexBuffers(0, [VertexBinding(renderable.mesh.vertexBuffer, 0)]);
+          commands.bindIndexBuffer(renderable.mesh.indexBuffer, 0, IndexType.u32);
+          if (renderable.descriptorSet !is null) commands.bindDescriptorSets(
+            PipelineBindPoint.graphics, cast(PipelineLayout) renderable.layout, 0,
+            cast(DescriptorSet[]) [renderable.descriptorSet], []
+          );
+          foreach (i, pushConstant; renderable.pushBindings) commands.pushConstants(
+            cast(PipelineLayout) renderable.layout, pushConstant.shaderStage, i, pushConstant.size, pushConstant.data.ptr
+          );
+          commands.drawIndexed(renderable.mesh.indices.length.to!uint, 1, 0, 0, 0);
+        }
+        commands.endRenderPass();
+        commands.end();
+
+        auto submissions = [Submission([], [], [commands])];
+        graphicsQueue.submit(submissions, null);
+        // Wait for frame to finish rendering
+        device.waitIdle();
+      }
     }
-    device.waitIdle();
-    destroy(renderTargetTexture);
-    renderPass.dispose();
-    frameBuffer.dispose();
+  }
 
-    device.waitIdle();
-    device.release();
-    unloadVulkan();
+  unittest {
+    version (GPU) {
+      import std.conv : to;
+
+      auto scene = new MockTriangleScene();
+      assert(scene.renderTargetTexture.initialized);
+
+      // Resize render target
+      scene.renderTargetTexture.resize(scene.renderTargetSize);
+      assert(!scene.renderTargetTexture.initialized);
+
+      scene.renderTargetTexture.initialize(scene.device);
+      assert(scene.renderTargetTexture.initialized);
+
+      // Render a triangle scene to a single image
+      scene.initializeWorld();
+      assert( scene.material.frontFace == FrontFace.clockwise);
+      assert( scene.material.cullMode == CullMode.back);
+      assert(!scene.material.textured);
+      assert(!scene.material.dirty);
+      assert(scene.triangle.dirty);
+      assert(scene.triangle.vertexCount == 3);
+      assert(scene.triangle.indices == [0, 1, 2]);
+
+      scene.update();
+      assert(scene.material.initialized);
+      assert(scene.triangle.initialized);
+
+      scene.renderFrame();
+      // TODO: Diff with a PPM file (https://github.com/aquaratixc/ppmformats), e.g. https://github.com/mruby/mruby/blob/master/benchmark/bm_ao_render.rb#L308
+
+      // Gracefully teardown GPU resources
+      destroy(scene);
+    }
   }
 }

--- a/source/teraflop/graphics/package.d
+++ b/source/teraflop/graphics/package.d
@@ -1126,7 +1126,11 @@ class Material : ObservableFileCollection, IResource {
     return shaderSet;
   }
 
+  /// Whether this Material is textured.
+  ///
+  /// Be sure to check `Material.textured` before accessing this property.
   Texture texture() @property const {
+    assert(textured, "This Material is not textured!\n\tHint: Check `Material.textured` beforehand.");
     return cast(Texture) _texture;
   }
   /// Whether this Material is textured.

--- a/source/teraflop/graphics/package.d
+++ b/source/teraflop/graphics/package.d
@@ -493,6 +493,12 @@ struct ModelViewProjection {
 ///   $(LI `teraflop.ecs.NamedComponent`)
 /// )
 abstract class BindingDescriptor : NamedComponent {
+  import teraflop.async : Event;
+
+  /// Fired when this BindingDescriptor's `data` changes.
+  /// See_Also: `BindingDescriptor.dirty`
+  Event!(const(ubyte)[]) onChanged;
+
   protected uint _bindingLocation;
   protected ShaderStage shaderStage_;
   protected DescriptorType bindingType_;
@@ -513,8 +519,10 @@ abstract class BindingDescriptor : NamedComponent {
   bool dirty() @property const {
     return dirty_;
   }
-  package (teraflop) void dirty(bool value) @property {
-    dirty_ = value;
+  package (teraflop) void dirty(bool value) @property const {
+    auto self = (cast(BindingDescriptor) this);
+    self.dirty_ = value;
+    if (value) self.onChanged(data);
   }
 
   /// Descriptor binding location, e.g. `layout(binding = 0)` in GLSL.

--- a/source/teraflop/graphics/package.d
+++ b/source/teraflop/graphics/package.d
@@ -883,6 +883,11 @@ class Texture : BindingDescriptor, IResource {
 
   /// Resize this Texture.
   void resize(Size size) {
+    import std.algorithm : joiner, map;
+    import std.array : array;
+    import std.math : round;
+    import std.range : repeat;
+
     this._data = [];
     this._size = size;
     if (stagingBuffer !is null) {
@@ -900,7 +905,13 @@ class Texture : BindingDescriptor, IResource {
       _sampler.dispose();
       _sampler = null;
     }
-    dirty = false;
+    // Fill the texture with transparent pixels
+    update(Color.transparent.repeat(size.width * size.height).map!(pixel => [
+      round(pixel.b * 255.0f).to!ubyte,
+      round(pixel.g * 255.0f).to!ubyte,
+      round(pixel.r * 255.0f).to!ubyte,
+      round(pixel.a * 255.0f).to!ubyte
+    ]).joiner.array);
   }
 
   /// Update this Texture's data.

--- a/source/teraflop/graphics/package.d
+++ b/source/teraflop/graphics/package.d
@@ -1417,7 +1417,8 @@ version (unittest) {
             cast(DescriptorSet[]) [renderable.descriptorSet], []
           );
           foreach (i, pushConstant; renderable.pushBindings) commands.pushConstants(
-            cast(PipelineLayout) renderable.layout, pushConstant.shaderStage, i, pushConstant.size, pushConstant.data.ptr
+            cast(PipelineLayout) renderable.layout, pushConstant.shaderStage, i,
+            pushConstant.size, pushConstant.data.ptr
           );
           commands.drawIndexed(renderable.mesh.indices.length.to!uint, 1, 0, 0, 0);
         }

--- a/source/teraflop/platform/vulkan.d
+++ b/source/teraflop/platform/vulkan.d
@@ -163,11 +163,14 @@ package (teraflop) Image createStencilImage(Device device, Size size) {
   return createImage(device, size, findStencilFormat(device.physicalDevice), ImageUsage.depthStencilAttachment);
 }
 
+///
+interface SurfaceSizeProvider {
+  const(Size) surfaceSize() @property const;
+}
+
 /// Data that is duplicated for every frame in the swapchain.
 /// This typically includes a framebuffer and command pool.
 abstract class FrameData : AtomicRefCounted {
-  import teraflop.math : Size;
-
   /// To keep track of when command processing is done.
   Rc!Fence fence;
   ///

--- a/source/teraflop/platform/window.d
+++ b/source/teraflop/platform/window.d
@@ -9,11 +9,12 @@ import bindbc.glfw;
 import std.exception : enforce;
 import std.string : toStringz;
 import teraflop.input;
+import teraflop.platform.vulkan : SurfaceSizeProvider;
 
 private uint lastWindowId = 0;
 
 /// A native window.
-class Window : InputNode {
+class Window : SurfaceSizeProvider, InputNode {
   import teraflop.async : Event;
   import teraflop.graphics : Color;
   import teraflop.math : Size, vec2d;
@@ -194,6 +195,14 @@ class Window : InputNode {
       // Maximum size
       data.maximumSize.width, data.maximumSize.height
     );
+  }
+
+  /// Size of this Window's Surface, in pixels.
+  ///
+  /// This value may not necessarily match `Window.size`. For example, on mac OS machines with high-DPI Retina displays.
+  /// See_Also: <a href="https://www.glfw.org/docs/3.3/window_guide.html#window_fbsize">Framebuffer size</a> in the GLFW documentation
+  const(Size) surfaceSize() @property const {
+    return data.framebufferSize;
   }
   /// Size of this Window, in pixels.
   ///

--- a/source/teraflop/systems/package.d
+++ b/source/teraflop/systems/package.d
@@ -43,9 +43,12 @@ final class ResourceGarbageCollector : System {
   }
 
   override void run() {
-    auto resources = query().map!(entity => entity.getMut!IResource).joiner
-      .filter!(c => c.initialized).array;
-    foreach (resource; resources) destroy(resource);
+    auto resources = query().map!(entity => cast(Component[]) entity.components).joiner
+      .filter!(c => typeid(IResource).isBaseOf(c.classinfo) && (cast(IResource) c).initialized).array;
+    foreach (resource; resources) {
+      device.waitIdle();
+      destroy(resource);
+    }
   }
 }
 

--- a/source/teraflop/systems/rendering.d
+++ b/source/teraflop/systems/rendering.d
@@ -91,9 +91,7 @@ final class PipelinePreparer : System {
     import std.range : tail;
     import std.typecons : No, Yes;
     import teraflop.components : Transform;
-
-    const window = this.resources.get!Window;
-    auto surfaceSize = window.framebufferSize;
+    import teraflop.platform : SurfaceSizeProvider;
 
     // Aggregate graphics pipelines
     foreach (entity; this.query()) {
@@ -196,6 +194,7 @@ final class PipelinePreparer : System {
         device.updateDescriptorSets(descriptorWrites, []);
       }
 
+      const surfaceSize = this.resources.get!SurfaceSizeProvider.surfaceSize;
       PipelineInfo info = {
         shaders: material.shaders,
         inputBindings: [mesh.bindingDescription],

--- a/source/teraflop/traits.d
+++ b/source/teraflop/traits.d
@@ -9,6 +9,8 @@ package enum bool isStruct(T) = is (T == struct);
 package enum bool isInterface(T) = is (T == interface);
 /// Detect whether `T` is a class type.
 package enum bool isClass(T) = is (T == class);
+/// Detect whether `T` is an interface or class type.
+package enum bool isHeritable(T) = isInterface!T || isClass!T;
 
 /// Detect whether `T` inherits from `U`.
 package template inheritsFrom(T, U) if (isClass!T && isClass!U) {


### PR DESCRIPTION
## Additions
- Add `BindingDescriptor.onChanged` `Event`
- Add `MaterialDirtied.shaderChanged`/`textureChanged` properties
- Add `SurfaceSizeProvider` interface
- Add `isHeritable` trait

## Changes
- Fill Textures with transparent pixels when resized